### PR TITLE
Bugs/queuedestroy

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -115,13 +115,18 @@ Queue.prototype.prefetch = function (num) {
 
 /**
  * Handles incoming messages after `listen`
- * @param  {} data [description]
- * @return {[type]}      [description]
+ * @param  {Function} cb listener
+ * @return {Function}
  */
 Queue.prototype.onMessage = function (cb) {
     cb = cb || nop;
     var self = this;
-    return function(data) {
+    return function (data) {
+        if (!data) {
+            //will be invoked with `null` when consumer is cancelled
+            return;
+        }
+
         var properties = data.properties;
         var headers = properties.headers;
         var fields = data.fields;

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -99,7 +99,7 @@ describe('queue wrapper', function () {
             queue.destroy({}, done);
         });
 
-        it.only('should work properly when conn.close follows a destroy with multiple listeners', function (done) {
+        it('should work properly when conn.close follows a destroy with multiple listeners', function (done) {
             queue.listen({}, function () {});
             queue.listen({}, function () {});
             queue.listen({}, function () {});

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -98,6 +98,23 @@ describe('queue wrapper', function () {
         it('should fire the callback when completed', function (done) {
             queue.destroy({}, done);
         });
+
+        it.only('should work properly when conn.close follows a destroy with multiple listeners', function (done) {
+            queue.listen({}, function () {});
+            queue.listen({}, function () {});
+            queue.listen({}, function () {});
+            queue.listen({}, function () {});
+
+            queue.listen({}, function () {}, function (err, tag) {
+                if (err) return done(err);
+
+                tag.length.should.be.greaterThan(1);
+
+                queue.destroy({}, function () {
+                    conn.close(done);
+                });
+            });
+        });
     });
 });
 


### PR DESCRIPTION
This PR fixes the issue demonstrated in @james-huston's unit test. 

If this fixes all the cases where we're trying to close a connection around when there are other operations pending, I'd rather not implement some other locking, though I have that ready to go if needed.

The issue in this case came from an error that we were swallowing. When you cancel a consumer – which happens during queue destruction – amqplib will invoke your listener function again with a single param of `null`. See the last line in this section for: http://www.squaremobius.net/amqp.node/doc/channel_api.html#toc_64

node-rabbit-wrap's internal handler didn't take this into account and was causing an error that triggered replay logic, which suggests that amqplib emits errors in `Channel#consume` listener functions in its connection error event. It also suggests that amqplib closed the connection after the internal handler errored, which I'm still trying to verify.

Anyway, this should fix that case. I need to write more tests to see if closing a connection allows completing actions to finish. 

**and we need debug logging so this sort of investigation is easier**
